### PR TITLE
Fix `FileManagementService` rename

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
   renamePairs:
     description: 'Mapping pairs for folder names'
     required: false
-    default: 'trust-registry=trustregistry,universal-wallet=wallet,verifiable-credentials=credential,templates=template,access-management=AccessManagement'
+    default: 'trust-registry=trustregistry,universal-wallet=wallet,verifiable-credentials=credential,templates=template,access-management=access_management,file-management=file_management'
   pythonPath:
     description: 'path for python output'
     required: false

--- a/build_test.ps1
+++ b/build_test.ps1
@@ -32,7 +32,7 @@ Else
 go build -o $BuildPath
 
 
-$RenamePairs = "trust-registry=trustregistry,universal-wallet=wallet,verifiable-credentials=credential,templates=template,access-management=AccessManagement,file-management=FileManagement"
+$RenamePairs = "trust-registry=trustregistry,universal-wallet=wallet,verifiable-credentials=credential,templates=template,access-management=access_management,file-management=file_management"
 
 # Default to doing nothing
 $PythonPath = "***SKIP***"


### PR DESCRIPTION
Fix the renaming pairs. @geel9 we always use `snake_case` for this, since that is the format `proto` expects.